### PR TITLE
alwaysActive nbt

### DIFF
--- a/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinel.java
+++ b/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinel.java
@@ -159,7 +159,7 @@ public class EntityGulingSentinel extends EntityAbsGuling implements IEntity, Gl
             @Override
             public void tick() {
                         if (alwaysActive()) {
-            setActive(true);
+            this.setActive(true);
         }
                 LivingEntity entityTarget = this.entity.getTarget();
                 this.entity.setDeltaMovement(0, this.entity.onGround() ? 0 : this.entity.getDeltaMovement().y, 0);

--- a/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinel.java
+++ b/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinel.java
@@ -61,6 +61,7 @@ public class EntityGulingSentinel extends EntityAbsGuling implements IEntity, Gl
     private int deactivateTick;
     private static final EntityDimensions DEACTIVATE_SIZE = EntityDimensions.scalable(1, 1);
     private static final EntityDataAccessor<Boolean> DATA_ACTIVE = SynchedEntityData.defineId(EntityGulingSentinel.class, EntityDataSerializers.BOOLEAN);
+    private static final EntityDataAccessor<Boolean> ALWAYS_ACTIVE = SynchedEntityData.defineId(EntityGulingSentinel.class, EntityDataSerializers.BOOLEAN);
 
     public EntityGulingSentinel(EntityType<? extends EEEABMobLibrary> type, Level level) {
         super(type, level);
@@ -280,7 +281,7 @@ public class EntityGulingSentinel extends EntityAbsGuling implements IEntity, Gl
         super.readAdditionalSaveData(compound);
         this.entityData.set(DATA_ACTIVE, compound.getBoolean("isActive"));
         this.active = this.isActive();
-        this.entityData.set(DATA_ACTIVE, compound.getBoolean("alwaysActive"));
+        this.entityData.set(ALWAYS_ACTIVE, compound.getBoolean("alwaysActive"));
         this.active = this.alwaysActive();
     }
 
@@ -288,7 +289,7 @@ public class EntityGulingSentinel extends EntityAbsGuling implements IEntity, Gl
     public void addAdditionalSaveData(CompoundTag compound) {
         super.addAdditionalSaveData(compound);
         compound.putBoolean("isActive", this.entityData.get(DATA_ACTIVE));
-         compound.putBoolean("alwaysActive", this.entityData.get(DATA_ACTIVE));
+         compound.putBoolean("alwaysActive", this.entityData.get(ALWAYS_ACTIVE));
     }
 
     @Override
@@ -322,11 +323,11 @@ public class EntityGulingSentinel extends EntityAbsGuling implements IEntity, Gl
         this.deactivateTick = 0;
     }
         public boolean alwaysActive() {
-        return this.entityData.get(DATA_ACTIVE);
+        return this.entityData.get(ALWAYS_ACTIVE);
     }
 
     public void setAlwaysActive(boolean alwaysActive) {
-        this.entityData.set(DATA_ACTIVE, alwaysActive);
+        this.entityData.set(ALWAYS_ACTIVE, alwaysActive);
     }
 
     @Override

--- a/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinel.java
+++ b/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinel.java
@@ -206,9 +206,7 @@ public class EntityGulingSentinel extends EntityAbsGuling implements IEntity, Gl
                 this.playAnimation(this.activeAnimation);
                 this.setActive(true);
             } else if (this.alwaysActive() && !this.isActive()) {
-                this.playSound(SoundInit.GSH_FRICTION.get());
-                this.playAnimation(this.activeAnimation);
-                this.setActive(true);  
+                this.isActive(true);  
             }
             if (!this.isNoAi() && this.isActive() && this.isNoAnimation() && this.getTarget() == null && this.deactivateTick >= 200) {
                 this.playSound(SoundInit.GSH_FRICTION.get());

--- a/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinel.java
+++ b/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinel.java
@@ -66,7 +66,6 @@ public class EntityGulingSentinel extends EntityAbsGuling implements IEntity, Gl
     public EntityGulingSentinel(EntityType<? extends EEEABMobLibrary> type, Level level) {
         super(type, level);
         this.active = false;
-        this.alwaysActive = false;
     }
 
     @Override
@@ -139,7 +138,7 @@ public class EntityGulingSentinel extends EntityAbsGuling implements IEntity, Gl
         this.goalSelector.addGoal(5, new WaterAvoidingRandomStrollGoal(this, 0.6D) {
             @Override
             public boolean canUse() {
-                return EntityGulingSentinel.this.alwaysActive && super.canUse();
+                return EntityGulingSentinel.this.active && super.canUse();
             }
         });
     }
@@ -289,7 +288,7 @@ public class EntityGulingSentinel extends EntityAbsGuling implements IEntity, Gl
         this.entityData.set(DATA_ACTIVE, compound.getBoolean("isActive"));
         this.active = this.isActive();
         this.entityData.set(ALWAYS_ACTIVE, compound.getBoolean("alwaysActive"));
-        this.alwaysActive = this.alwaysActive();
+        this.active = this.alwaysActive();
     }
 
     @Override

--- a/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinel.java
+++ b/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinel.java
@@ -159,7 +159,7 @@ public class EntityGulingSentinel extends EntityAbsGuling implements IEntity, Gl
             @Override
             public void tick() {
                         if (alwaysActive()) {
-            this.setActive(true);
+            setActive(true);
         }
                 LivingEntity entityTarget = this.entity.getTarget();
                 this.entity.setDeltaMovement(0, this.entity.onGround() ? 0 : this.entity.getDeltaMovement().y, 0);
@@ -205,6 +205,11 @@ public class EntityGulingSentinel extends EntityAbsGuling implements IEntity, Gl
                 this.playSound(SoundInit.GSH_FRICTION.get());
                 this.playAnimation(this.activeAnimation);
                 this.setActive(true);
+            else if (this.alwaysActive() && !this.isActive()) {
+                this.playSound(SoundInit.GSH_FRICTION.get());
+                this.playAnimation(this.activeAnimation);
+                this.setActive(true);  
+            }
             }
             if (!this.isNoAi() && this.isActive() && this.isNoAnimation() && this.getTarget() == null && this.deactivateTick >= 200) {
                 this.playSound(SoundInit.GSH_FRICTION.get());

--- a/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinel.java
+++ b/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinel.java
@@ -274,6 +274,7 @@ public class EntityGulingSentinel extends EntityAbsGuling implements IEntity, Gl
     protected void defineSynchedData() {
         super.defineSynchedData();
         this.entityData.define(DATA_ACTIVE, false);
+        this.entityData.define(ALWAYS_ACTIVE, false);
     }
 
     @Override

--- a/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinel.java
+++ b/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinel.java
@@ -210,7 +210,6 @@ public class EntityGulingSentinel extends EntityAbsGuling implements IEntity, Gl
                 this.playAnimation(this.activeAnimation);
                 this.setActive(true);  
             }
-            }
             if (!this.isNoAi() && this.isActive() && this.isNoAnimation() && this.getTarget() == null && this.deactivateTick >= 200) {
                 this.playSound(SoundInit.GSH_FRICTION.get());
                 this.playAnimation(this.deactivateAnimation);

--- a/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinel.java
+++ b/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinel.java
@@ -280,12 +280,15 @@ public class EntityGulingSentinel extends EntityAbsGuling implements IEntity, Gl
         super.readAdditionalSaveData(compound);
         this.entityData.set(DATA_ACTIVE, compound.getBoolean("isActive"));
         this.active = this.isActive();
+        this.entityData.set(DATA_ACTIVE, compound.getBoolean("alwaysActive"));
+        this.active = this.alwaysActive();
     }
 
     @Override
     public void addAdditionalSaveData(CompoundTag compound) {
         super.addAdditionalSaveData(compound);
         compound.putBoolean("isActive", this.entityData.get(DATA_ACTIVE));
+         compound.putBoolean("alwaysActive", this.entityData.get(DATA_ACTIVE));
     }
 
     @Override
@@ -317,6 +320,13 @@ public class EntityGulingSentinel extends EntityAbsGuling implements IEntity, Gl
     public void setActive(boolean isActive) {
         this.entityData.set(DATA_ACTIVE, isActive);
         this.deactivateTick = 0;
+    }
+        public boolean alwaysActive() {
+        return this.entityData.get(DATA_ACTIVE);
+    }
+
+    public void setAlwaysActive(boolean alwaysActive) {
+        this.entityData.set(DATA_ACTIVE, alwaysActive);
     }
 
     @Override

--- a/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinel.java
+++ b/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinel.java
@@ -205,7 +205,7 @@ public class EntityGulingSentinel extends EntityAbsGuling implements IEntity, Gl
                 this.playSound(SoundInit.GSH_FRICTION.get());
                 this.playAnimation(this.activeAnimation);
                 this.setActive(true);
-            else if (this.alwaysActive() && !this.isActive()) {
+            } else if (this.alwaysActive() && !this.isActive()) {
                 this.playSound(SoundInit.GSH_FRICTION.get());
                 this.playAnimation(this.activeAnimation);
                 this.setActive(true);  

--- a/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinel.java
+++ b/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinel.java
@@ -237,7 +237,7 @@ public class EntityGulingSentinel extends EntityAbsGuling implements IEntity, Gl
             if (this.attackTick > 0) {
                 this.attackTick--;
             }
-            if (this.isActive()) {
+            if (this.isActive() && !this.alwaysActive()) {
                 if (this.getTarget() == null) {
                     this.deactivateTick++;
                 } else if (this.deactivateTick > 0) {

--- a/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinel.java
+++ b/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinel.java
@@ -158,6 +158,9 @@ public class EntityGulingSentinel extends EntityAbsGuling implements IEntity, Gl
 
             @Override
             public void tick() {
+                        if (isAlwaysActive()) {
+            setActive(true);
+        }
                 LivingEntity entityTarget = this.entity.getTarget();
                 this.entity.setDeltaMovement(0, this.entity.onGround() ? 0 : this.entity.getDeltaMovement().y, 0);
                 int tick = this.entity.getAnimationTick();

--- a/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinel.java
+++ b/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinel.java
@@ -66,6 +66,7 @@ public class EntityGulingSentinel extends EntityAbsGuling implements IEntity, Gl
     public EntityGulingSentinel(EntityType<? extends EEEABMobLibrary> type, Level level) {
         super(type, level);
         this.active = false;
+        this.alwaysActive = false;
     }
 
     @Override
@@ -138,7 +139,7 @@ public class EntityGulingSentinel extends EntityAbsGuling implements IEntity, Gl
         this.goalSelector.addGoal(5, new WaterAvoidingRandomStrollGoal(this, 0.6D) {
             @Override
             public boolean canUse() {
-                return EntityGulingSentinel.this.active && super.canUse();
+                return EntityGulingSentinel.this.alwaysActive && super.canUse();
             }
         });
     }
@@ -288,7 +289,7 @@ public class EntityGulingSentinel extends EntityAbsGuling implements IEntity, Gl
         this.entityData.set(DATA_ACTIVE, compound.getBoolean("isActive"));
         this.active = this.isActive();
         this.entityData.set(ALWAYS_ACTIVE, compound.getBoolean("alwaysActive"));
-        this.active = this.alwaysActive();
+        this.alwaysActive = this.alwaysActive();
     }
 
     @Override

--- a/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinel.java
+++ b/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinel.java
@@ -206,7 +206,7 @@ public class EntityGulingSentinel extends EntityAbsGuling implements IEntity, Gl
                 this.playAnimation(this.activeAnimation);
                 this.setActive(true);
             } else if (this.alwaysActive() && !this.isActive()) {
-                this.isActive(true);  
+                this.setActive(true);  
             }
             if (!this.isNoAi() && this.isActive() && this.isNoAnimation() && this.getTarget() == null && this.deactivateTick >= 200) {
                 this.playSound(SoundInit.GSH_FRICTION.get());

--- a/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinel.java
+++ b/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinel.java
@@ -158,7 +158,7 @@ public class EntityGulingSentinel extends EntityAbsGuling implements IEntity, Gl
 
             @Override
             public void tick() {
-                        if (isAlwaysActive()) {
+                        if (alwaysActive()) {
             setActive(true);
         }
                 LivingEntity entityTarget = this.entity.getTarget();

--- a/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinelHeavy.java
+++ b/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinelHeavy.java
@@ -47,6 +47,7 @@ import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.ai.control.BodyRotationControl;
+import net.minecraft.world.entity.ai.goal.WaterAvoidingRandomStrollGoal;
 import net.minecraft.world.entity.ai.goal.RandomLookAroundGoal;
 import net.minecraft.world.entity.ai.goal.target.HurtByTargetGoal;
 import net.minecraft.world.entity.ai.goal.target.NearestAttackableTargetGoal;

--- a/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinelHeavy.java
+++ b/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinelHeavy.java
@@ -91,6 +91,7 @@ public class EntityGulingSentinelHeavy extends EntityAbsGuling implements IEntit
             electromagneticAnimation
     };
     private static final EntityDataAccessor<Boolean> DATA_ACTIVE = SynchedEntityData.defineId(EntityGulingSentinelHeavy.class, EntityDataSerializers.BOOLEAN);
+    private static final EntityDataAccessor<Boolean> ALWAYS_ACTIVE = SynchedEntityData.defineId(EntityGulingSentinelHeavy.class, EntityDataSerializers.BOOLEAN);
     private int deactivateTick;
     private int smashAttackTick;
     private int rangeAttackTick;
@@ -223,6 +224,9 @@ public class EntityGulingSentinelHeavy extends EntityAbsGuling implements IEntit
         this.goalSelector.addGoal(1, new AnimationRepel<>(this, () -> smashAttackAnimation, 7F, 18, 1.5F, 1.5F, true) {
             @Override
             public void tick() {
+                 if (alwaysActive()) {
+            setActive(true);
+               }
                 this.entity.setDeltaMovement(0F, 0F, 0F);
                 LivingEntity target = this.entity.getTarget();
                 if (target != null) {
@@ -269,6 +273,8 @@ public class EntityGulingSentinelHeavy extends EntityAbsGuling implements IEntit
                 this.playSound(SoundInit.GSH_FRICTION.get());
                 this.playAnimation(this.activeAnimation);
                 this.setActive(true);
+            }     else if (this.alwaysActive() && !this.isActive()) {
+                this.setActive(true);  
             }
             if (!this.isNoAi() && this.isActive() && this.isAlive() && this.isNoAnimation() && this.getTarget() == null && this.deactivateTick >= 300) {
                 this.playSound(SoundInit.GSH_FRICTION.get());
@@ -414,7 +420,7 @@ public class EntityGulingSentinelHeavy extends EntityAbsGuling implements IEntit
             }
 
             if (this.isActive()) {
-                if (this.getTarget() == null || (this.tickCount % 2 == 0 && !this.getSensing().hasLineOfSight(this.getTarget()))) {
+                if (!this.alwaysActive() && this.getTarget() == null || (this.tickCount % 2 == 0 && !this.getSensing().hasLineOfSight(this.getTarget()))) {
                     this.deactivateTick++;
                 } else if (this.deactivateTick > 0) {
                     this.deactivateTick--;
@@ -458,6 +464,7 @@ public class EntityGulingSentinelHeavy extends EntityAbsGuling implements IEntit
     protected void defineSynchedData() {
         super.defineSynchedData();
         this.entityData.define(DATA_ACTIVE, false);
+        this.entityData.define(ALWAYS_ACTIVE, false);
     }
 
     @Override
@@ -465,12 +472,15 @@ public class EntityGulingSentinelHeavy extends EntityAbsGuling implements IEntit
         super.readAdditionalSaveData(compound);
         this.entityData.set(DATA_ACTIVE, compound.getBoolean("isActive"));
         this.active = this.isActive();
+        this.entityData.set(ALWAYS_ACTIVE, compound.getBoolean("alwaysActive"));
+        this.active = this.alwaysActive();
     }
 
     @Override
     public void addAdditionalSaveData(CompoundTag compound) {
         super.addAdditionalSaveData(compound);
         compound.putBoolean("isActive", this.entityData.get(DATA_ACTIVE));
+        compound.putBoolean("alwaysActive", this.entityData.get(ALWAYS_ACTIVE));
     }
 
     @Override
@@ -570,6 +580,13 @@ public class EntityGulingSentinelHeavy extends EntityAbsGuling implements IEntit
     public void setActive(boolean isActive) {
         this.entityData.set(DATA_ACTIVE, isActive);
         this.deactivateTick = 0;
+    }
+            public boolean alwaysActive() {
+        return this.entityData.get(ALWAYS_ACTIVE);
+    }
+
+    public void setAlwaysActive(boolean alwaysActive) {
+        this.entityData.set(ALWAYS_ACTIVE, alwaysActive);
     }
 
 

--- a/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinelHeavy.java
+++ b/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinelHeavy.java
@@ -204,11 +204,11 @@ public class EntityGulingSentinelHeavy extends EntityAbsGuling implements IEntit
         this.targetSelector.addGoal(1, new HurtByTargetGoal(this, EntityAbsGuling.class));
         this.targetSelector.addGoal(2, new NearestAttackableTargetGoal<>(this, Player.class, 0, true, false, null));
         this.targetSelector.addGoal(3, new NearestAttackableTargetGoal<>(this, AbstractGolem.class, 0, false, false, (golem) -> !(golem instanceof Shulker)));
-        this.goalSelector.addGoal(5, new WaterAvoidingRandomStrollGoal(this, 1.0D)); {
+        this.goalSelector.addGoal(5, new WaterAvoidingRandomStrollGoal(this, 1.0D)) {
             @Override
             public boolean canUse() {
                 return super.canUse() && EntityGulingSentinelHeavy.this.active;
-            }    
+            }};    
         this.goalSelector.addGoal(6, new EMLookAtGoal(this, Mob.class, 6.0F));
         this.goalSelector.addGoal(7, new EMLookAtGoal(this, Player.class, 8.0F));
         this.goalSelector.addGoal(8, new RandomLookAroundGoal(this) {

--- a/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinelHeavy.java
+++ b/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinelHeavy.java
@@ -204,7 +204,11 @@ public class EntityGulingSentinelHeavy extends EntityAbsGuling implements IEntit
         this.targetSelector.addGoal(1, new HurtByTargetGoal(this, EntityAbsGuling.class));
         this.targetSelector.addGoal(2, new NearestAttackableTargetGoal<>(this, Player.class, 0, true, false, null));
         this.targetSelector.addGoal(3, new NearestAttackableTargetGoal<>(this, AbstractGolem.class, 0, false, false, (golem) -> !(golem instanceof Shulker)));
-        this.goalSelector.addGoal(5, new WaterAvoidingRandomStrollGoal(this, 1.0D));     
+        this.goalSelector.addGoal(5, new WaterAvoidingRandomStrollGoal(this, 1.0D)); {
+            @Override
+            public boolean canUse() {
+                return super.canUse() && EntityGulingSentinelHeavy.this.active;
+            }    
         this.goalSelector.addGoal(6, new EMLookAtGoal(this, Mob.class, 6.0F));
         this.goalSelector.addGoal(7, new EMLookAtGoal(this, Player.class, 8.0F));
         this.goalSelector.addGoal(8, new RandomLookAroundGoal(this) {

--- a/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinelHeavy.java
+++ b/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinelHeavy.java
@@ -204,7 +204,7 @@ public class EntityGulingSentinelHeavy extends EntityAbsGuling implements IEntit
         this.targetSelector.addGoal(1, new HurtByTargetGoal(this, EntityAbsGuling.class));
         this.targetSelector.addGoal(2, new NearestAttackableTargetGoal<>(this, Player.class, 0, true, false, null));
         this.targetSelector.addGoal(3, new NearestAttackableTargetGoal<>(this, AbstractGolem.class, 0, false, false, (golem) -> !(golem instanceof Shulker)));
-        this.goalSelector.addGoal(5, new WaterAvoidingRandomStrollGoal(this, 1.5D));     
+        this.goalSelector.addGoal(5, new WaterAvoidingRandomStrollGoal(this, 1.0D));     
         this.goalSelector.addGoal(6, new EMLookAtGoal(this, Mob.class, 6.0F));
         this.goalSelector.addGoal(7, new EMLookAtGoal(this, Player.class, 8.0F));
         this.goalSelector.addGoal(8, new RandomLookAroundGoal(this) {

--- a/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinelHeavy.java
+++ b/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinelHeavy.java
@@ -207,7 +207,7 @@ public class EntityGulingSentinelHeavy extends EntityAbsGuling implements IEntit
         this.goalSelector.addGoal(5, new WaterAvoidingRandomStrollGoal(this, 1.0D) {
             @Override
             public boolean canUse() {
-                return super.canUse() && EntityGulingSentinelHeavy.this.active;
+                return super.canUse() && alwaysActive();
             }
         });    
         this.goalSelector.addGoal(6, new EMLookAtGoal(this, Mob.class, 6.0F));

--- a/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinelHeavy.java
+++ b/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinelHeavy.java
@@ -204,11 +204,12 @@ public class EntityGulingSentinelHeavy extends EntityAbsGuling implements IEntit
         this.targetSelector.addGoal(1, new HurtByTargetGoal(this, EntityAbsGuling.class));
         this.targetSelector.addGoal(2, new NearestAttackableTargetGoal<>(this, Player.class, 0, true, false, null));
         this.targetSelector.addGoal(3, new NearestAttackableTargetGoal<>(this, AbstractGolem.class, 0, false, false, (golem) -> !(golem instanceof Shulker)));
-        this.goalSelector.addGoal(5, new WaterAvoidingRandomStrollGoal(this, 1.0D)) {
+        this.goalSelector.addGoal(5, new WaterAvoidingRandomStrollGoal(this, 1.0D) {
             @Override
             public boolean canUse() {
                 return super.canUse() && EntityGulingSentinelHeavy.this.active;
-            }};    
+            }
+        });    
         this.goalSelector.addGoal(6, new EMLookAtGoal(this, Mob.class, 6.0F));
         this.goalSelector.addGoal(7, new EMLookAtGoal(this, Player.class, 8.0F));
         this.goalSelector.addGoal(8, new RandomLookAroundGoal(this) {

--- a/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinelHeavy.java
+++ b/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinelHeavy.java
@@ -203,7 +203,7 @@ public class EntityGulingSentinelHeavy extends EntityAbsGuling implements IEntit
         this.targetSelector.addGoal(1, new HurtByTargetGoal(this, EntityAbsGuling.class));
         this.targetSelector.addGoal(2, new NearestAttackableTargetGoal<>(this, Player.class, 0, true, false, null));
         this.targetSelector.addGoal(3, new NearestAttackableTargetGoal<>(this, AbstractGolem.class, 0, false, false, (golem) -> !(golem instanceof Shulker)));
-        this.goalSelector.addGoal(5, new WaterAvoidingRandomStrollGoal(this, 0.6D) {      
+        this.goalSelector.addGoal(5, new WaterAvoidingRandomStrollGoal(this, 0.6D);     
         this.goalSelector.addGoal(6, new EMLookAtGoal(this, Mob.class, 6.0F));
         this.goalSelector.addGoal(7, new EMLookAtGoal(this, Player.class, 8.0F));
         this.goalSelector.addGoal(8, new RandomLookAroundGoal(this) {

--- a/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinelHeavy.java
+++ b/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinelHeavy.java
@@ -204,7 +204,7 @@ public class EntityGulingSentinelHeavy extends EntityAbsGuling implements IEntit
         this.targetSelector.addGoal(1, new HurtByTargetGoal(this, EntityAbsGuling.class));
         this.targetSelector.addGoal(2, new NearestAttackableTargetGoal<>(this, Player.class, 0, true, false, null));
         this.targetSelector.addGoal(3, new NearestAttackableTargetGoal<>(this, AbstractGolem.class, 0, false, false, (golem) -> !(golem instanceof Shulker)));
-        this.goalSelector.addGoal(5, new WaterAvoidingRandomStrollGoal(this, 0.6D));     
+        this.goalSelector.addGoal(5, new WaterAvoidingRandomStrollGoal(this, 1.5D));     
         this.goalSelector.addGoal(6, new EMLookAtGoal(this, Mob.class, 6.0F));
         this.goalSelector.addGoal(7, new EMLookAtGoal(this, Player.class, 8.0F));
         this.goalSelector.addGoal(8, new RandomLookAroundGoal(this) {

--- a/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinelHeavy.java
+++ b/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinelHeavy.java
@@ -203,7 +203,7 @@ public class EntityGulingSentinelHeavy extends EntityAbsGuling implements IEntit
         this.targetSelector.addGoal(1, new HurtByTargetGoal(this, EntityAbsGuling.class));
         this.targetSelector.addGoal(2, new NearestAttackableTargetGoal<>(this, Player.class, 0, true, false, null));
         this.targetSelector.addGoal(3, new NearestAttackableTargetGoal<>(this, AbstractGolem.class, 0, false, false, (golem) -> !(golem instanceof Shulker)));
-        this.goalSelector.addGoal(5, new WaterAvoidingRandomStrollGoal(this, 0.6D);     
+        this.goalSelector.addGoal(5, new WaterAvoidingRandomStrollGoal(this, 0.6D));     
         this.goalSelector.addGoal(6, new EMLookAtGoal(this, Mob.class, 6.0F));
         this.goalSelector.addGoal(7, new EMLookAtGoal(this, Player.class, 8.0F));
         this.goalSelector.addGoal(8, new RandomLookAroundGoal(this) {

--- a/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinelHeavy.java
+++ b/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinelHeavy.java
@@ -420,7 +420,7 @@ public class EntityGulingSentinelHeavy extends EntityAbsGuling implements IEntit
             }
 
             if (this.isActive()) {
-                if (!this.alwaysActive() && this.getTarget() == null || (this.tickCount % 2 == 0 && !this.getSensing().hasLineOfSight(this.getTarget()))) {
+                if (!this.alwaysActive() && this.getTarget() == null || (!this.alwaysActive() && this.tickCount % 2 == 0 && !this.getSensing().hasLineOfSight(this.getTarget()))) {
                     this.deactivateTick++;
                 } else if (this.deactivateTick > 0) {
                     this.deactivateTick--;

--- a/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinelHeavy.java
+++ b/src/main/java/com/eeeab/eeeabsmobs/sever/entity/guling/EntityGulingSentinelHeavy.java
@@ -203,6 +203,7 @@ public class EntityGulingSentinelHeavy extends EntityAbsGuling implements IEntit
         this.targetSelector.addGoal(1, new HurtByTargetGoal(this, EntityAbsGuling.class));
         this.targetSelector.addGoal(2, new NearestAttackableTargetGoal<>(this, Player.class, 0, true, false, null));
         this.targetSelector.addGoal(3, new NearestAttackableTargetGoal<>(this, AbstractGolem.class, 0, false, false, (golem) -> !(golem instanceof Shulker)));
+        this.goalSelector.addGoal(5, new WaterAvoidingRandomStrollGoal(this, 0.6D) {      
         this.goalSelector.addGoal(6, new EMLookAtGoal(this, Mob.class, 6.0F));
         this.goalSelector.addGoal(7, new EMLookAtGoal(this, Player.class, 8.0F));
         this.goalSelector.addGoal(8, new RandomLookAroundGoal(this) {


### PR DESCRIPTION
Hello I modified Guling Sentinel and Heavy Guling Sentinel. 
This change lets you make them have a {alwaysActive:1} so they won't go back to inactive state when lose target.
+ Heavy Guling Sentinel will also wander around if {alwaysActive:1}

Their original behavior is unchanged, this is for creative only.